### PR TITLE
Optimize hex operations

### DIFF
--- a/src/main/java/com/privacylogistics/FF3Cipher.java
+++ b/src/main/java/com/privacylogistics/FF3Cipher.java
@@ -155,7 +155,7 @@ public class FF3Cipher {
         }
 
         // Calculate the tweak
-        logger.trace("tweak: {}", byteArrayToHexString(this.tweakBytes));
+        logger.trace("tweak: {}", () -> byteArrayToHexString(this.tweakBytes));
 
         byte[] tweak64 = (this.tweakBytes.length == TWEAK_LEN_NEW) ?
                 calculateTweak64_FF3_1(this.tweakBytes) : this.tweakBytes;
@@ -172,7 +172,7 @@ public class FF3Cipher {
         BigInteger modU = BigInteger.valueOf(this.radix).pow(u);
         BigInteger modV = BigInteger.valueOf(this.radix).pow(v);
         logger.trace("u {} v {} modU: {} modV: {}", u, v, modU, modV);
-        logger.trace("tL: {} tR: {}", byteArrayToHexString(Tl), byteArrayToHexString(Tr));
+        logger.trace("tL: {} tR: {}", () -> byteArrayToHexString(Tl), () -> byteArrayToHexString(Tr));
 
         for (byte i = 0; i < NUM_ROUNDS; ++i) {
             int m;
@@ -195,7 +195,7 @@ public class FF3Cipher {
             // Calculate S by operating on P in place
             byte[] S = this.aesCipher.doFinal(P);
             reverseBytes(S);
-            logger.trace("\tS: {}", byteArrayToHexString(S));
+            logger.trace("\tS: {}", () -> byteArrayToHexString(S));
 
             BigInteger y = new BigInteger(byteArrayToHexString(S), 16);
 
@@ -266,7 +266,7 @@ public class FF3Cipher {
         }
 
         // Calculate the tweak
-        logger.trace("tweak: {}", byteArrayToHexString(this.tweakBytes));
+        logger.trace("tweak: {}", () -> byteArrayToHexString(this.tweakBytes));
 
         byte[] tweak64 = (this.tweakBytes.length == TWEAK_LEN_NEW) ?
                 calculateTweak64_FF3_1(this.tweakBytes) : this.tweakBytes;
@@ -283,7 +283,7 @@ public class FF3Cipher {
         BigInteger modU = BigInteger.valueOf(this.radix).pow(u);
         BigInteger modV = BigInteger.valueOf(this.radix).pow(v);
         logger.trace("modU: {} modV: {}", modU, modV);
-        logger.trace("tL: {} tR: {}", byteArrayToHexString(Tl), byteArrayToHexString(Tr));
+        logger.trace("tL: {} tR: {}", () -> byteArrayToHexString(Tl), () -> byteArrayToHexString(Tr));
 
         for (byte i = (byte) (NUM_ROUNDS - 1); i >= 0; --i) {
             int m;
@@ -306,7 +306,7 @@ public class FF3Cipher {
             // Calculate S by operating on P in place
             byte[] S = this.aesCipher.doFinal(P);
             reverseBytes(S);
-            logger.trace("\tS: {}", byteArrayToHexString(S));
+            logger.trace("\tS: {}", () -> byteArrayToHexString(S));
 
             BigInteger y = new BigInteger(byteArrayToHexString(S), 16);
 
@@ -380,7 +380,7 @@ public class FF3Cipher {
         byte[] bBytes = decode_int(B, alphabet).toByteArray();
 
         System.arraycopy(bBytes, 0, P, (BLOCK_SIZE - bBytes.length), bBytes.length);
-        logger.trace("round: {} W: {} P: {}", i, byteArrayToHexString(W), byteArrayToIntString(P));
+        logger.trace("round: {} W: {} P: {}", () -> i, () -> byteArrayToHexString(W), () -> byteArrayToIntString(P));
         return P;
     }
 

--- a/src/main/java/com/privacylogistics/FF3Cipher.java
+++ b/src/main/java/com/privacylogistics/FF3Cipher.java
@@ -441,16 +441,7 @@ public class FF3Cipher {
      * @return           a decimal string encoding of a number
      */
     protected static String byteArrayToIntString(byte[] byteArray) {
-
-        StringBuilder sb = new StringBuilder();
-        sb.append('[');
-        for (byte b : byteArray) {
-            // cast signed byte to int and mask for last byte
-            String aByte = String.format("%d ", ((int) b) & 0xFF);
-            sb.append(aByte);
-        }
-        sb.append(']');
-        return sb.toString();
+        return Arrays.toString(byteArray);
     }
 
     /**

--- a/src/main/java/com/privacylogistics/FF3Cipher.java
+++ b/src/main/java/com/privacylogistics/FF3Cipher.java
@@ -17,6 +17,7 @@ package com.privacylogistics;
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import java.nio.charset.StandardCharsets;
 import javax.crypto.*;
 import javax.crypto.spec.SecretKeySpec;
 import java.math.BigInteger;
@@ -412,7 +413,8 @@ public class FF3Cipher {
     protected static byte[] hexStringToByteArray(String s) {
         byte[] data = new byte[s.length() / 2];
         for (int i = 0; i < s.length(); i += 2) {
-            data[i / 2] = (Integer.decode("0x" + s.charAt(i) + s.charAt(i + 1))).byteValue();
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                + Character.digit(s.charAt(i+1), 16));
         }
         return data;
     }
@@ -424,13 +426,13 @@ public class FF3Cipher {
      * @return           a hex string encoding of a number
      */
     protected static String byteArrayToHexString(byte[] byteArray) {
-
-        StringBuilder sb = new StringBuilder();
-        for (byte b : byteArray) {
-            String aByte = String.format("%02X", b);
-            sb.append(aByte);
+        byte[] hexChars = new byte[byteArray.length * 2];
+        for (int j = 0; j < byteArray.length; j++) {
+            int v = byteArray[j] & 0xFF;
+            hexChars[j * 2] = (byte) HEX_ARRAY[v >>> 4];
+            hexChars[j * 2 + 1] = (byte) HEX_ARRAY[v & 0x0F];
         }
-        return sb.toString();
+        return new String(hexChars, StandardCharsets.UTF_8);
     }
 
     /**
@@ -526,6 +528,7 @@ public class FF3Cipher {
         }
     }
 
+    private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
     private static final int NUM_ROUNDS =   8;
     private static final int BLOCK_SIZE =   16;      // aes.BlockSize
     private static final int TWEAK_LEN =    8;       // Original FF3 64-bit tweak length

--- a/src/main/java/com/privacylogistics/FF3Cipher.java
+++ b/src/main/java/com/privacylogistics/FF3Cipher.java
@@ -420,7 +420,6 @@ public class FF3Cipher {
     }
 
     /**
-     * used for debugging
      * Java 17 has java.util.HexFormat
      * @param byteArray  a byte array
      * @return           a hex string encoding of a number


### PR DESCRIPTION
Hi there. 

I really like your library. So we've tried to use it in our production project. However, we quickly found that the performance is quite low - it takes seconds to encode just thousands of strings. I had a look into hot spots using profiler and found that array operations for hex and string representation take too much time.

I've applied optimisations and seems it helped.  Here are the measurements using jmh:

**Baseline (master) version:**

```
Benchmark                   Mode  Cnt     Score     Error  Units
FF3CipherPerf.testEncrypt  thrpt    5  7216.611 ± 281.185  ops/s
```

**UPDATED: Optimised version (this pull request):**

```
Benchmark                   Mode  Cnt      Score     Error  Units
FF3CipherPerf.testEncrypt  thrpt    5  93495.731 ± 370.602  ops/s
```

More than 10x improvement! I hope you will find this contribution useful.
