### PR TITLE
Fix radix value for the largest alphabet from 64 to correct 62

### DIFF
--- a/src/main/java/com/privacylogistics/FF3Cipher.java
+++ b/src/main/java/com/privacylogistics/FF3Cipher.java
@@ -511,7 +511,7 @@ public class FF3Cipher {
                 return DIGITS + "abcdefghijklmnop";
             case 36:
                 return DIGITS + ASCII_UPPERCASE;
-            case 64:
+            case 62:
                 return DIGITS + ASCII_UPPERCASE + ASCII_LOWERCASE;
             default:
                 throw new RuntimeException("Unsupported radix");


### PR DESCRIPTION
Number of characters in the largest alphabet is 62, not 64