### PR TITLE
Fix tweak side effect

### DIFF
--- a/src/test/java/com/privacylogistics/FF3CipherTest.java
+++ b/src/test/java/com/privacylogistics/FF3CipherTest.java
@@ -264,4 +264,25 @@ public class FF3CipherTest {
         String plaintext = c.decrypt(ciphertext);
         assertEquals(pt, plaintext);
     }
+
+    @Test
+    void testTweakHasNoSideEffects() throws Exception {
+        String key = "EF4359D8D580AA4F7F036D6F04FC6A94";
+        String tweak = "D8E7920AFA330A73";
+        String tweak2 = "0000000000000000";
+        String alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+        FF3Cipher c = new FF3Cipher(key, tweak, alphabet);
+        String pt = "Foobar";
+
+        String ciphertext1 = c.encrypt(pt);
+        String ciphertext2 = c.encrypt(pt, tweak);
+        assertEquals(ciphertext1, ciphertext2);
+
+        String ciphertext3 = c.encrypt(pt, tweak2); // this will NOT overwrite the initial tweak
+        assertNotEquals(ciphertext1, ciphertext3); // different ciphertexts because different tweaks were used
+
+        String ciphertext4 = c.encrypt(pt); // will still use the initial tweak
+        assertEquals(ciphertext1, ciphertext4);
+    }
 }


### PR DESCRIPTION
Tweak is a mandatory argument when instantiating an `FF3Cipher`. By requiring this, one can later invoke `encrypt/decypt` without having to specify tweak explicitly.

However, a side effect exists: if the tweak is specified explicitly when invoking encrypt/decrypt, then the initial/internal tweak is also overwritten. This can be pretty confusing and might lead to error situations.

IMHO I think it would be more intuitive if the "initial" tweak is immutable.

A code example says more than a thousand words 😉:
```java
    @Test
    void testTweakHasNoSideEffects() throws Exception {
        FF3Cipher ff3 = new FF3Cipher(KEY, TWEAK, ALPHABET);
        String plaintext = "Foobar";

        String ciphertext1 = ff3.encrypt(plaintext);
        String ciphertext2 = ff3.encrypt(plaintext, TWEAK);
        assertEquals(ciphertext1, ciphertext2);

        ff3.encrypt(plaintext, TWEAK2); // !!! this overwrites the initial tweak !!!
        
        String ciphertext3 = ff3.encrypt(plaintext);
        assertEquals(ciphertext1, ciphertext3); // fails since the "initial tweak" was updated with TWEAK2
    }
```

This PR is just a suggestion to how one could avoid the issue.