### PR TITLE
Feat.no string allocs

### DIFF
--- a/src/main/java/com/privacylogistics/FF3Cipher.java
+++ b/src/main/java/com/privacylogistics/FF3Cipher.java
@@ -312,8 +312,10 @@ public class FF3Cipher {
         int v = n - u;
 
         // Split the message
-        char[] A = ciphertext.substring(0, u).toCharArray();
-        char[] B = ciphertext.substring(u).toCharArray();
+        char[] A = new char[u];
+        char[] B = new char[v];
+        ciphertext.getChars(0, u, A, 0);
+        ciphertext.getChars(u, ciphertext.length(), B, 0);
 
         if ((tweak.length != TWEAK_LEN) && (tweak.length != TWEAK_LEN_NEW)) {
             throw new IllegalArgumentException(String.format("tweak length %d is invalid: tweak must be 56 or 64 bits",

--- a/src/main/java/com/privacylogistics/FF3Cipher.java
+++ b/src/main/java/com/privacylogistics/FF3Cipher.java
@@ -156,8 +156,11 @@ public class FF3Cipher {
         int v = n - u;
 
         // Split the message
-        char[] A = plaintext.substring(0, u).toCharArray();
-        char[] B = plaintext.substring(u).toCharArray();
+        char[] A = new char[u];
+        char[] B = new char[v];
+        plaintext.getChars(0, u, A, 0);
+        plaintext.getChars(u, plaintext.length(), B, 0);
+
         logger.trace("r {} A {} B {}", this.radix, A, B);
 
         if ((tweak.length != TWEAK_LEN) && (tweak.length != TWEAK_LEN_NEW)) {

--- a/src/test/java/com/privacylogistics/FF3CipherTest.java
+++ b/src/test/java/com/privacylogistics/FF3CipherTest.java
@@ -26,7 +26,7 @@ import java.math.BigInteger;
 
 import static com.privacylogistics.FF3Cipher.reverseString;
 import static com.privacylogistics.FF3Cipher.encode_int_r;
-import static com.privacylogistics.FF3Cipher.decode_int;
+import static com.privacylogistics.FF3Cipher.decode_int_r;
 
 public class FF3CipherTest {
 
@@ -141,7 +141,7 @@ public class FF3CipherTest {
         String alphabet = "0123456789";
         String B = "567890000";
         byte[] W = FF3Cipher.hexStringToByteArray("FA330A73");
-        byte[] P = FF3Cipher.calculateP(i, alphabet, W, B);
+        byte[] P = FF3Cipher.calculateP(i, alphabet, W, B.toCharArray());
         assertArrayEquals(P, new byte[]
                 {(byte) 250, 51, 10, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, (byte) 129, (byte) 205});
     }
@@ -156,21 +156,21 @@ public class FF3CipherTest {
 
     @Test
     public void testEncodeBigInt() {
-        assertEquals("101", reverseString(encode_int_r(BigInteger.valueOf(5), "01", 3)));
-        assertEquals("11", reverseString(encode_int_r(BigInteger.valueOf(6), "01234", 2)));
-        assertEquals("00012", reverseString(encode_int_r(BigInteger.valueOf(7), "01234", 5)));
-        assertEquals("a", reverseString(encode_int_r(BigInteger.valueOf(10), "0123456789abcdef", 1)));
-        assertEquals("20", reverseString(encode_int_r(BigInteger.valueOf(32), "0123456789abcdef", 2)));
+        assertEquals("101", reverseString(new String(encode_int_r(BigInteger.valueOf(5), "01", 3))));
+        assertEquals("11", reverseString(new String(encode_int_r(BigInteger.valueOf(6), "01234", 2))));
+        assertEquals("00012", reverseString(new String(encode_int_r(BigInteger.valueOf(7), "01234", 5))));
+        assertEquals("a", reverseString(new String(encode_int_r(BigInteger.valueOf(10), "0123456789abcdef", 1))));
+        assertEquals("20", reverseString(new String(encode_int_r(BigInteger.valueOf(32), "0123456789abcdef", 2))));
     }
 
     @Test
     public void testDecodeInt() {
-        assertEquals(BigInteger.valueOf(321), (decode_int("321", "0123456789")));
-        assertEquals(BigInteger.valueOf(101), (decode_int("101", "0123456789")));
-        assertEquals(BigInteger.valueOf(101), (decode_int("00101", "0123456789")));
-        assertEquals(BigInteger.valueOf(0x02), (decode_int("02", "0123456789abcdef")));
-        assertEquals(BigInteger.valueOf(0xAA), (decode_int("aa", "0123456789abcdef")));
-        assertEquals(new BigInteger("2658354847544284194395037922"), (decode_int("2658354847544284194395037922", "0123456789")));
+        assertEquals(BigInteger.valueOf(123), (decode_int_r("321".toCharArray(), "0123456789")));
+        assertEquals(BigInteger.valueOf(101), (decode_int_r("101".toCharArray(), "0123456789")));
+        assertEquals(BigInteger.valueOf(10100), (decode_int_r("00101".toCharArray(), "0123456789")));
+        assertEquals(BigInteger.valueOf(0x20), (decode_int_r("02".toCharArray(), "0123456789abcdef")));
+        assertEquals(BigInteger.valueOf(0xAA), (decode_int_r("aa".toCharArray(), "0123456789abcdef")));
+        assertEquals(new BigInteger("2297305934914824457484538562"), (decode_int_r("2658354847544284194395037922".toCharArray(), "0123456789")));
     }
 
     @Test

--- a/src/test/java/com/privacylogistics/FF3CipherTest.java
+++ b/src/test/java/com/privacylogistics/FF3CipherTest.java
@@ -167,7 +167,7 @@ public class FF3CipherTest {
     public void testDecodeInt() {
         assertEquals(BigInteger.valueOf(123), (decode_int_r("321".toCharArray(), "0123456789")));
         assertEquals(BigInteger.valueOf(101), (decode_int_r("101".toCharArray(), "0123456789")));
-        assertEquals(BigInteger.valueOf(10100), (decode_int_r("00101".toCharArray(), "0123456789")));
+        assertEquals(BigInteger.valueOf(101), (decode_int_r("10100".toCharArray(), "0123456789")));
         assertEquals(BigInteger.valueOf(0x20), (decode_int_r("02".toCharArray(), "0123456789abcdef")));
         assertEquals(BigInteger.valueOf(0xAA), (decode_int_r("aa".toCharArray(), "0123456789abcdef")));
         assertEquals(new BigInteger("2297305934914824457484538562"), (decode_int_r("2658354847544284194395037922".toCharArray(), "0123456789")));


### PR DESCRIPTION
### Refactor String -> char[], decode int in reverse

Refactor the methods `decode_int` and `encode_int_r` to accept/return
char arrays rather than Strings to reduce the number of allocations.

Change the behavior of `decode_int` to decode its char[] input in
reverse, rather than reversing its input. This method's name is also
changed to `decode_int_r` to reflect its behavior.

These changes net a modest 6.8% improvement in the existing benchmark
suite on a 16GB M1 Pro:

```
Original:
Benchmark                   Mode  Cnt      Score      Error  Units
FF3CipherPerf.testEncrypt  thrpt    5  93096.351 ± 1781.433  ops/s

New:
Benchmark                   Mode  Cnt      Score      Error  Units
FF3CipherPerf.testEncrypt  thrpt    5  99928.775 ± 1557.381  ops/s
```
